### PR TITLE
feat: add OIDC authentication configuration with validation and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,17 @@ The application is configured using environment variables. The primary configura
 - `LOG_LEVEL`: Controls logging verbosity. Options: `debug`, `info` (default), `warning`, `error`.
 - `LOG_HEALTH`: Controls whether requests to the `/health` endpoint are logged. Defaults to `false`. Set to `true` to enable health check logs.
 
+### Authentication (OIDC)
+
+Authentication is optional. To enable OIDC-based authentication, all of the following environment variables must be set:
+
+- `OIDC_ISSUER`: The URL of the OIDC issuer (e.g., `https://accounts.google.com`).
+- `OIDC_AUDIENCE`: The expected audience (client ID) for the tokens.
+- `OIDC_JWKS_URL`: The URL to the issuer's JSON Web Key Set (JWKS) (e.g., `https://www.googleapis.com/oauth2/v3/certs`).
+
+If any of these variables are missing, authentication will be disabled.
+_Note:_ this is still a work in progress and not fully functional
+
 ### Database Connectivity & Secrets Management
 
 Service Atlas supports multiple "Providers" for retrieving database credentials.

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -8,25 +8,39 @@ import (
 )
 
 type AuthConfig struct {
-	Enabled  bool
-	Issuer   string
-	Audience string
-	JWKSURL  string
+	enabled  bool
+	issuer   string
+	audience string
+	jwksURL  string
+}
+
+func (cfg *AuthConfig) Enabled() bool {
+	return cfg.enabled
+}
+
+func (cfg *AuthConfig) Issuer() string {
+	return cfg.issuer
+}
+func (cfg *AuthConfig) Audience() string {
+	return cfg.audience
+}
+func (cfg *AuthConfig) JWKSURL() string {
+	return cfg.jwksURL
 }
 
 func NewAuthConfig() (*AuthConfig, error) {
 	cfg := AuthConfig{
-		Enabled:  false,
-		JWKSURL:  "",
-		Issuer:   "",
-		Audience: "",
+		enabled:  false,
+		jwksURL:  "",
+		issuer:   "",
+		audience: "",
 	}
 	oidcIssuer := strings.TrimSpace(os.Getenv("OIDC_ISSUER"))
 	oidcAudience := strings.TrimSpace(os.Getenv("OIDC_AUDIENCE"))
 	oidcJWKSURL := strings.TrimSpace(os.Getenv("OIDC_JWKS_URL"))
 
 	if oidcIssuer == "" && oidcAudience == "" && oidcJWKSURL == "" {
-		cfg.Enabled = false
+		cfg.enabled = false
 		return &cfg, nil
 	}
 
@@ -40,10 +54,10 @@ func NewAuthConfig() (*AuthConfig, error) {
 	}
 
 	if partialFound == 3 {
-		cfg.Enabled = true
-		cfg.Issuer = oidcIssuer
-		cfg.Audience = oidcAudience
-		cfg.JWKSURL = oidcJWKSURL
+		cfg.enabled = true
+		cfg.issuer = oidcIssuer
+		cfg.audience = oidcAudience
+		cfg.jwksURL = oidcJWKSURL
 	} else if partialFound < 3 {
 		errMsg := "OIDC_ISSUER, OIDC_AUDIENCE, and OIDC_JWKS_URL must be set"
 		slog.Error(errMsg, slog.String("OIDC_ISSUER", oidcIssuer), slog.String("OIDC_AUDIENCE", oidcAudience), slog.String("OIDC_JWKS_URL", oidcJWKSURL))

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -1,0 +1,54 @@
+package auth
+
+import (
+	"errors"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+type AuthConfig struct {
+	Enabled  bool
+	Issuer   string
+	Audience string
+	JWKSURL  string
+}
+
+func NewAuthConfig() (*AuthConfig, error) {
+	cfg := AuthConfig{
+		Enabled:  false,
+		JWKSURL:  "",
+		Issuer:   "",
+		Audience: "",
+	}
+	oidcIssuer := strings.TrimSpace(os.Getenv("OIDC_ISSUER"))
+	oidcAudience := strings.TrimSpace(os.Getenv("OIDC_AUDIENCE"))
+	oidcJWKSURL := strings.TrimSpace(os.Getenv("OIDC_JWKS_URL"))
+
+	if oidcIssuer == "" && oidcAudience == "" && oidcJWKSURL == "" {
+		cfg.Enabled = false
+		return &cfg, nil
+	}
+
+	lengths := []int{len(oidcIssuer), len(oidcAudience), len(oidcJWKSURL)}
+
+	partialFound := 0
+	for _, l := range lengths {
+		if l > 0 {
+			partialFound++
+		}
+	}
+
+	if partialFound == 3 {
+		cfg.Enabled = true
+		cfg.Issuer = oidcIssuer
+		cfg.Audience = oidcAudience
+		cfg.JWKSURL = oidcJWKSURL
+	} else if partialFound < 3 {
+		errMsg := "OIDC_ISSUER, OIDC_AUDIENCE, and OIDC_JWKS_URL must be set"
+		slog.Error(errMsg, slog.String("OIDC_ISSUER", oidcIssuer), slog.String("OIDC_AUDIENCE", oidcAudience), slog.String("OIDC_JWKS_URL", oidcJWKSURL))
+		return nil, errors.New(errMsg)
+	}
+
+	return &cfg, nil
+}

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -1,0 +1,106 @@
+package auth
+
+import (
+	"testing"
+)
+
+func TestNewAuthConfig(t *testing.T) {
+	tests := []struct {
+		name         string
+		env          map[string]string
+		wantEnabled  bool
+		wantIssuer   string
+		wantAudience string
+		wantJWKSURL  string
+		wantErr      bool
+	}{
+		{
+			name: "All variables unset",
+			env: map[string]string{
+				"OIDC_ISSUER":   "",
+				"OIDC_AUDIENCE": "",
+				"OIDC_JWKS_URL": "",
+			},
+			wantEnabled: false,
+			wantErr:     false,
+		},
+		{
+			name: "All variables set",
+			env: map[string]string{
+				"OIDC_ISSUER":   "https://issuer.com",
+				"OIDC_AUDIENCE": "audience",
+				"OIDC_JWKS_URL": "https://issuer.com/.well-known/jwks.json",
+			},
+			wantEnabled:  true,
+			wantIssuer:   "https://issuer.com",
+			wantAudience: "audience",
+			wantJWKSURL:  "https://issuer.com/.well-known/jwks.json",
+			wantErr:      false,
+		},
+		{
+			name: "Only Issuer set",
+			env: map[string]string{
+				"OIDC_ISSUER": "https://issuer.com",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Only Audience set",
+			env: map[string]string{
+				"OIDC_AUDIENCE": "audience",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Only JWKS URL set",
+			env: map[string]string{
+				"OIDC_JWKS_URL": "https://issuer.com/.well-known/jwks.json",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Issuer and Audience set, JWKS URL missing",
+			env: map[string]string{
+				"OIDC_ISSUER":   "https://issuer.com",
+				"OIDC_AUDIENCE": "audience",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clear relevant env vars first to ensure clean state
+			t.Setenv("OIDC_ISSUER", "")
+			t.Setenv("OIDC_AUDIENCE", "")
+			t.Setenv("OIDC_JWKS_URL", "")
+
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			cfg, err := NewAuthConfig()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NewAuthConfig() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr {
+				return
+			}
+
+			if cfg.Enabled != tt.wantEnabled {
+				t.Errorf("NewAuthConfig() Enabled = %v, want %v", cfg.Enabled, tt.wantEnabled)
+			}
+			if cfg.Issuer != tt.wantIssuer {
+				t.Errorf("NewAuthConfig() Issuer = %v, want %v", cfg.Issuer, tt.wantIssuer)
+			}
+			if cfg.Audience != tt.wantAudience {
+				t.Errorf("NewAuthConfig() Audience = %v, want %v", cfg.Audience, tt.wantAudience)
+			}
+			if cfg.JWKSURL != tt.wantJWKSURL {
+				t.Errorf("NewAuthConfig() JWKSURL = %v, want %v", cfg.JWKSURL, tt.wantJWKSURL)
+			}
+		})
+	}
+}

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -66,6 +66,16 @@ func TestNewAuthConfig(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "Whitespace variables",
+			env: map[string]string{
+				"OIDC_ISSUER":   "   ",
+				"OIDC_AUDIENCE": "   ",
+				"OIDC_JWKS_URL": "   ",
+			},
+			wantEnabled: false,
+			wantErr:     false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -89,17 +99,17 @@ func TestNewAuthConfig(t *testing.T) {
 				return
 			}
 
-			if cfg.Enabled != tt.wantEnabled {
-				t.Errorf("NewAuthConfig() Enabled = %v, want %v", cfg.Enabled, tt.wantEnabled)
+			if cfg.Enabled() != tt.wantEnabled {
+				t.Errorf("NewAuthConfig() Enabled = %v, want %v", cfg.Enabled(), tt.wantEnabled)
 			}
-			if cfg.Issuer != tt.wantIssuer {
-				t.Errorf("NewAuthConfig() Issuer = %v, want %v", cfg.Issuer, tt.wantIssuer)
+			if cfg.Issuer() != tt.wantIssuer {
+				t.Errorf("NewAuthConfig() Issuer = %v, want %v", cfg.Issuer(), tt.wantIssuer)
 			}
-			if cfg.Audience != tt.wantAudience {
-				t.Errorf("NewAuthConfig() Audience = %v, want %v", cfg.Audience, tt.wantAudience)
+			if cfg.Audience() != tt.wantAudience {
+				t.Errorf("NewAuthConfig() Audience = %v, want %v", cfg.Audience(), tt.wantAudience)
 			}
-			if cfg.JWKSURL != tt.wantJWKSURL {
-				t.Errorf("NewAuthConfig() JWKSURL = %v, want %v", cfg.JWKSURL, tt.wantJWKSURL)
+			if cfg.JWKSURL() != tt.wantJWKSURL {
+				t.Errorf("NewAuthConfig() JWKSURL = %v, want %v", cfg.JWKSURL(), tt.wantJWKSURL)
 			}
 		})
 	}


### PR DESCRIPTION
- Introduced `OIDC_ISSUER`, `OIDC_AUDIENCE`, and `OIDC_JWKS_URL` environment variables for OIDC configuration.
- Added `NewAuthConfig` to validate and enable authentication only when all variables are set.
- Implemented unit tests to cover various OIDC configuration scenarios.
- Updated documentation to include details for configuring OIDC authentication.

## Description

<!-- Provide a short description of what this PR is changing -->
### Code Rabbit Summary
<!-- This section allows Code Rabbit to generate a summary -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OIDC authentication configuration is now supported via environment variables (OIDC_ISSUER, OIDC_AUDIENCE, OIDC_JWKS_URL). When all three variables are set, OIDC authentication is enabled; missing or incomplete configuration disables the feature. Currently a work in progress and not fully functional.

* **Documentation**
  * README includes new OIDC authentication configuration section with setup instructions.

* **Tests**
  * Added test coverage for OIDC configuration validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Fixes
<!-- Add any issues that this PR closes here -->
Closes #198 

## Post Deployment Tasks?
