### PR TITLE
Fixes created and updated timestamps to server time

### DIFF
--- a/api/services/create.go
+++ b/api/services/create.go
@@ -38,6 +38,8 @@ func (u *ServiceCallsHandler) CreateService(rw http.ResponseWriter, r *http.Requ
 	rw.Header().Set("Content-Type", "application/json; charset=UTF-8")
 	rw.WriteHeader(http.StatusCreated)
 	createServiceRequest.Id = id
+	createServiceRequest.Created = time.Now().UTC()
+	createServiceRequest.Updated = createServiceRequest.Created
 	err = json.NewEncoder(rw).Encode(createServiceRequest)
 	if err != nil {
 		logger.Error("Error encoding response:",

--- a/api/services/create_test.go
+++ b/api/services/create_test.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestPOSTSuccess(t *testing.T) {
@@ -62,7 +63,14 @@ func TestPOSTSuccess(t *testing.T) {
 		t.Errorf("Service POST errored with ServiceType inconsistency %s", returnedService.ServiceType)
 	case returnedService.Url != "http://test.com":
 		t.Errorf("Service POST errored with Url inconsistency %s", returnedService.Url)
-
+	case returnedService.Created.IsZero():
+		t.Errorf("Service POST errored: Created time is zero")
+	case returnedService.Updated.IsZero():
+		t.Errorf("Service POST errored: Updated time is zero")
+	case time.Since(returnedService.Created) > 5*time.Second:
+		t.Errorf("Service POST errored: Created time is not approximately now: %v", returnedService.Created)
+	case time.Since(returnedService.Updated) > 5*time.Second:
+		t.Errorf("Service POST errored: Updated time is not approximately now: %v", returnedService.Updated)
 	}
 
 }

--- a/api/services/update.go
+++ b/api/services/update.go
@@ -7,6 +7,7 @@ import (
 	"service-atlas/internal"
 	"service-atlas/internal/customerrors"
 	"service-atlas/repositories"
+	"time"
 )
 
 func (u *ServiceCallsHandler) UpdateService(rw http.ResponseWriter, r *http.Request) {
@@ -37,6 +38,12 @@ func (u *ServiceCallsHandler) UpdateService(rw http.ResponseWriter, r *http.Requ
 		customerrors.HandleError(rw, err)
 		return
 	}
-	rw.WriteHeader(http.StatusNoContent)
-
+	updateServiceRequest.Updated = time.Now().UTC()
+	rw.Header().Set("Content-Type", "application/json; charset=UTF-8")
+	rw.WriteHeader(http.StatusOK)
+	err = json.NewEncoder(rw).Encode(updateServiceRequest)
+	if err != nil {
+		logger.Error("Error encoding response:",
+			slog.String("error", err.Error()))
+	}
 }

--- a/api/services/update_test.go
+++ b/api/services/update_test.go
@@ -9,6 +9,7 @@ import (
 	"service-atlas/repositories"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestUpdateServiceSuccess(t *testing.T) {
@@ -21,6 +22,7 @@ func TestUpdateServiceSuccess(t *testing.T) {
 					"name":        "ExistingService",
 					"type":        "Internal",
 					"description": "Existing service description",
+					"updated":     time.Now().UTC().String(),
 				})
 				return m
 			},
@@ -45,8 +47,21 @@ func TestUpdateServiceSuccess(t *testing.T) {
 	rw := httptest.NewRecorder()
 	handler.UpdateService(rw, req)
 
-	if rw.Code != http.StatusNoContent {
-		t.Errorf("Service UPDATE returned wrong status code: got %v want %v", rw.Code, http.StatusNoContent)
+	if rw.Code != http.StatusOK {
+		t.Errorf("Service UPDATE returned wrong status code: got %v want %v", rw.Code, http.StatusOK)
+	}
+
+	returnedService := &repositories.Service{}
+	err = json.Unmarshal(rw.Body.Bytes(), &returnedService)
+	if err != nil {
+		t.Errorf("Service UPDATE errored parsing return body with %s", err.Error())
+	}
+
+	if returnedService.Updated.IsZero() {
+		t.Errorf("Service UPDATE errored: Updated time is zero")
+	}
+	if time.Since(returnedService.Updated) > 5*time.Second {
+		t.Errorf("Service UPDATE errored: Updated time is not approximately now: %v", returnedService.Updated)
 	}
 }
 


### PR DESCRIPTION
## Description

<!-- Provide a short description of what this PR is changing -->
### Code Rabbit Summary
<!-- This section allows Code Rabbit to generate a summary -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Service creation responses now include current `Created` and `Updated` timestamps.
  * Service updates now return HTTP 200 with the updated service details.
  * Updated services include a refreshed `Updated` timestamp.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Fixes
<!-- Add any issues that this PR closes here -->
Closes #205
